### PR TITLE
Update subscription installment amount from $640.38 to $640.39

### DIFF
--- a/index.html
+++ b/index.html
@@ -930,8 +930,8 @@
                       <option value="" disabled selected>
                         Select Installment Plan
                       </option>
-                      <option value="2-installment">
-                        2 Installments ($640.38 x 2)
+                      <option value="2-installment" data-per-amount="640.39">
+                        2 Installments ($640.39 x 2)
                       </option>
                     </select>
                     <p class="mt-2 text-muted">

--- a/script.js
+++ b/script.js
@@ -817,7 +817,14 @@ if (typeof document !== "undefined") {
           installments = m ? Number(m[1]) : installments;
         }
         if (!installments || installments < 1) installments = 2;
-        const per = base / installments;
+        let per = base / installments;
+        if (planSelect) {
+          const selected = planSelect.options[planSelect.selectedIndex];
+          if (selected && selected.dataset && selected.dataset.perAmount) {
+            const override = parseFloat(selected.dataset.perAmount);
+            if (!Number.isNaN(override) && override > 0) per = override;
+          }
+        }
         const perStr = per.toFixed(2);
         if (amountEl) amountEl.textContent = `${currencySymbol}${perStr} / installment (x${installments})`;
         if (amountInputEl) amountInputEl.value = `${perStr}${currency}/installment x${installments}`;


### PR DESCRIPTION
## Purpose
Update the subscription installment amount display from $640.38 to $640.39 as requested by the user. The user reported that previous changes were not visible, so this implementation ensures the corrected amount is properly displayed.

## Code changes
- **HTML**: Updated the 2-installment option text from "$640.38 x 2" to "$640.39 x 2" and added `data-per-amount="640.39"` attribute
- **JavaScript**: Added logic to check for and use the `data-per-amount` attribute value when calculating installment amounts, allowing for precise control over displayed amounts instead of relying solely on division calculations

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f47b86a35714fa9aa131dabcff0722e/swoosh-zone)

👀 [Preview Link](https://1f47b86a35714fa9aa131dabcff0722e-swoosh-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f47b86a35714fa9aa131dabcff0722e</projectId>-->
<!--<branchName>swoosh-zone</branchName>-->