### PR TITLE
Fix country field validation selector

### DIFF
--- a/script.js
+++ b/script.js
@@ -302,7 +302,7 @@ if (typeof document !== "undefined") {
         pattern: /^.{2,10}$/,
         message: "Postal code is required.",
       },
-      "country-select": {
+      "country": {
         required: true,
         message: "Please select your country.",
       },


### PR DESCRIPTION
## Purpose
Review and fix the form fields validation system to ensure proper field targeting and validation rules are correctly applied.

## Code changes
Updated the country field validation selector from `"country-select"` to `"country"` to match the actual form field identifier, ensuring the validation rule is properly applied to the country selection field.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f47b86a35714fa9aa131dabcff0722e/pulse-lab)

👀 [Preview Link](https://1f47b86a35714fa9aa131dabcff0722e-pulse-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f47b86a35714fa9aa131dabcff0722e</projectId>-->
<!--<branchName>pulse-lab</branchName>-->