### PR TITLE
Remove address line 1 validation requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,7 +604,6 @@
                         id="address-line1"
                         name="address-line1"
                         placeholder="Address Line 1"
-                        required
                       />
                       <input
                         type="text"

--- a/script.js
+++ b/script.js
@@ -300,7 +300,7 @@ if (typeof document !== "undefined") {
         message: "Please enter a valid phone number.",
       },
       "address-line1": {
-        required: true,
+        required: false,
         message: "Street address is required.",
       },
       city: { required: false, message: "" },
@@ -760,8 +760,8 @@ if (typeof document !== "undefined") {
       const format = addressFormats[countryCode] || addressFormats.default;
       try {
         format.fields.forEach((field) => {
+          field.required = false;
           if (field.id !== "address-line1") {
-            field.required = false;
             field.pattern = null;
             field.error = "";
           }


### PR DESCRIPTION
## Purpose
Remove the validation requirement for address line 1 field to make it optional instead of mandatory for form submission.

## Code changes
- Removed `required` attribute from address-line1 input field in HTML
- Updated JavaScript validation to set `required: false` for address-line1 field
- Modified address format validation logic to set all fields (including address-line1) as non-required

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f47b86a35714fa9aa131dabcff0722e/nova-studio)

👀 [Preview Link](https://1f47b86a35714fa9aa131dabcff0722e-nova-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f47b86a35714fa9aa131dabcff0722e</projectId>-->
<!--<branchName>nova-studio</branchName>-->