### PR TITLE
Remove address field validators but keep required validation

### DIFF
--- a/script.js
+++ b/script.js
@@ -760,11 +760,8 @@ if (typeof document !== "undefined") {
       const format = addressFormats[countryCode] || addressFormats.default;
       try {
         format.fields.forEach((field) => {
-          field.required = false;
-          if (field.id !== "address-line1") {
-            field.pattern = null;
-            field.error = "";
-          }
+          field.pattern = null;
+          field.error = "";
         });
       } catch {}
       format.fields.forEach((f) => {
@@ -783,6 +780,7 @@ if (typeof document !== "undefined") {
               message: f.error || "",
             };
           }
+          validationRules[f.id].required = !!f.required;
 
           validationRules[f.id].pattern = f.pattern || null;
           validationRules[f.id].message =


### PR DESCRIPTION
## Purpose
Remove pattern-based address validation from address fields while maintaining required field validation to ensure fields are not left blank.

## Code changes
- Removed the conditional logic that set `field.required = false` and only cleared patterns for non-address-line1 fields
- Now clears `field.pattern` and `field.error` for all address fields uniformly
- Added explicit setting of `validationRules[f.id].required = !!f.required` to preserve the original required field behavior
- Maintains required validation while removing pattern-based address format validation

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f47b86a35714fa9aa131dabcff0722e/zenith-den)

👀 [Preview Link](https://1f47b86a35714fa9aa131dabcff0722e-zenith-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f47b86a35714fa9aa131dabcff0722e</projectId>-->
<!--<branchName>zenith-den</branchName>-->