### PR TITLE
Replace auto-redirect with continue button in success modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,8 +224,7 @@
         <div class="modal-content text-center p-4">
           <div class="modal-body">
             <i
-              class="bi bi-check-circle-fill text-success"
-              style="font-size: 3rem"
+              class="bi bi-check-circle-fill text-success modal-success-icon"
             ></i>
             <h2 id="digitalCurrencyModalTitle" class="mt-3 mb-2">
               Form Submitted Successfully!
@@ -234,8 +233,11 @@
               Your payment portal has been generated and a payment window is now open. Please complete the required payment promptly to avoid disconnection of your subscription.
             </p>
             <p class="text-muted small mt-3">
-              Please note: your payment portal has been generated and a payment window is open. You have 24 hours to complete payment. Complete the required payment within this window to avoid disconnection of your subscription. You will be redirected to <a href="https://hybecorp.com" class="text-decoration-none">hybecorp.com</a> in <span id="digital-currency-countdown">5</span> seconds...
+              Please note: your payment portal has been generated and a payment window is open. You have 24 hours to complete payment. Complete the required payment within this window to avoid disconnection of your subscription.
             </p>
+            <div class="d-grid mt-3">
+              <a href="/success" class="btn btn-primary btn-gradient" id="continue-to-success">Continue</a>
+            </div>
           </div>
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -1111,15 +1111,7 @@ if (typeof document !== "undefined") {
           const pm = document.querySelector('input[name="payment-method"]:checked');
           const paymentValue = pm ? pm.value : null;
           if (paymentValue === "Digital Currency" || paymentValue === "Card Payment") {
-            modalManager.show("digitalCurrencySuccessModal", {
-              countdown: {
-                duration: 5,
-                elementId: "digital-currency-countdown",
-                onComplete: () => {
-                  try { window.location.href = "/success"; } catch (e) { console.error(e); }
-                },
-              },
-            });
+            modalManager.show("digitalCurrencySuccessModal");
           } else {
             showRedirectOverlayAndGo();
           }

--- a/styles.css
+++ b/styles.css
@@ -672,3 +672,8 @@ footer a[lang="ko"] {
 .redirect-icon {
   font-size: 2rem;
 }
+
+/* Success icon and logo sizing */
+.modal-success-icon { font-size: 3rem; }
+.page-success-icon { font-size: 3.5rem; }
+.success-logo { max-width: 120px; }

--- a/success.html
+++ b/success.html
@@ -51,19 +51,20 @@
                 <img
                   src="https://logotyp.us/file/hybe.svg"
                   alt="HYBE Logo"
-                  class="img-fluid mb-4 logo-pulse"
-                  style="max-width: 120px"
+                  class="img-fluid mb-4 logo-pulse success-logo"
                 />
                 <div class="success-icon mb-3">
                   <i
-                    class="bi bi-check-circle-fill text-success"
-                    style="font-size: 3.5rem"
+                    class="bi bi-check-circle-fill text-success page-success-icon"
                   ></i>
                 </div>
                 <h1 class="h3 mb-2 fw-bold">Submission Successful!</h1>
                 <p class="lead mb-4">
                   Thank you for subscribing to the HYBE Fan-Permit 2025/2026.
                 </p>
+                <div class="alert alert-info text-start" role="alert">
+                  Subscription validation is pending and awaiting payment confirmation. Your HYBE profile and subscription will be fully active upon payment confirmation.
+                </div>
 
                 <div id="submission-summary-container" class="text-start">
                   <!-- Submission data will be injected here -->


### PR DESCRIPTION
## Purpose

The user requested to improve the subscription flow by replacing the automatic 5-second redirect with a manual continue button. This allows users to read the success message carefully and proceed at their own pace. Additionally, they wanted to enhance the success page with clear messaging about subscription validation status and payment confirmation requirements.

## Code changes

- **Modal improvements**: Removed automatic countdown timer and redirect functionality from the success modal
- **Continue button**: Added a "Continue" button that manually navigates users to the success page
- **Success page enhancement**: Added an informational alert explaining that subscription validation is pending payment confirmation and that the HYBE profile will be fully active upon payment
- **CSS organization**: Moved inline styles to CSS classes for better maintainability (`modal-success-icon`, `page-success-icon`, `success-logo`)
- **JavaScript cleanup**: Removed countdown logic and automatic redirect code from the modal manager

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/076a0e10495446a6b8b191acbb81f9da/pixel-works)

👀 [Preview Link](https://076a0e10495446a6b8b191acbb81f9da-pixel-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>076a0e10495446a6b8b191acbb81f9da</projectId>-->
<!--<branchName>pixel-works</branchName>-->