### PR TITLE
Feat: Use geo-detection for phone prefix

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@
                       Phone Number <span class="text-danger">*</span>
                     </label>
                     <div class="input-group">
-                      <span id="phone-prefix" class="input-group-text phone-prefix">🇳🇬 +234</span>
+                      <span id="phone-prefix" class="input-group-text phone-prefix">🌐</span>
                       <input
                         type="tel"
                         class="form-control"


### PR DESCRIPTION
### Purpose

Based on the conversation history, the user wanted to remove the hardcoded Nigerian country code (+234) from the phone number input field. The goal is to default to geo-detection to automatically determine the user's country code, rather than having a static default.

### Code changes

- In `index.html`, the content of the `span` element with the ID `phone-prefix` has been updated.
- The hardcoded Nigerian flag and country code (`🇳🇬 +234`) have been replaced with a globe emoji (`🌐`) to represent the new geo-detection functionality.


<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/efd354d117be405da145c7b32e0f694c/stellar-verse)

👀 [Preview Link](https://efd354d117be405da145c7b32e0f694c-stellar-verse.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>efd354d117be405da145c7b32e0f694c</projectId>-->
<!--<branchName>stellar-verse</branchName>-->